### PR TITLE
Create the world

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,39 +1,26 @@
 use crate::util::{self, take_argument};
-use crate::{Character, Connection, ObjectInRoomAdapter, PlayerRecord, Room, RoomId};
-use fnv::FnvHashMap as HashMap;
-use generational_arena::{Arena, Index};
-use intrusive_collections::LinkedList;
+use crate::{PlayerRecord, RoomId, World};
+use generational_arena::Index;
 use std::io::{Result as IoResult, Write};
 
-pub type CommandFn = fn(
-    &mut Connection,
-    &str,
-    &mut Arena<Character>,
-    &HashMap<RoomId, Room>,
-    &mut HashMap<RoomId, Vec<Index>>,
-    &mut HashMap<RoomId, LinkedList<ObjectInRoomAdapter>>,
-) -> IoResult<()>;
+pub type CommandFn = fn(Index, &str, &mut World) -> IoResult<()>;
 
-pub fn define_commands() -> Vec<(&'static str, CommandFn)> {
-    vec![
-        ("north", north),
-        ("south", south),
-        ("east", east),
-        ("west", west),
-        ("look", look),
-        ("save", save),
-    ]
-}
+pub const COMMANDS: &[(&'static str, CommandFn)] = &[
+    ("north", north),
+    ("south", south),
+    ("east", east),
+    ("west", west),
+    ("look", look),
+    ("save", save),
+];
 
-pub fn save(
-    conn: &mut Connection,
-    _arguments: &str,
-    characters: &mut Arena<Character>,
-    _rooms: &HashMap<RoomId, Room>,
-    _room_chars: &mut HashMap<RoomId, Vec<Index>>,
-    _room_objs: &mut HashMap<RoomId, LinkedList<ObjectInRoomAdapter>>,
-) -> IoResult<()> {
-    let character = characters
+pub fn save(conn_idx: Index, _arguments: &str, world: &mut World) -> IoResult<()> {
+    let conn = world
+        .connections
+        .get_mut(conn_idx)
+        .expect("Unwrapped None connection");
+    let character = world
+        .characters
         .get(conn.character)
         .expect("Unwrapped None character")
         .clone();
@@ -47,25 +34,31 @@ pub fn save(
     }
 }
 
-pub fn look(
-    conn: &mut Connection,
-    arguments: &str,
-    characters: &mut Arena<Character>,
-    rooms: &HashMap<RoomId, Room>,
-    room_chars: &mut HashMap<RoomId, Vec<Index>>,
-    room_objs: &mut HashMap<RoomId, LinkedList<ObjectInRoomAdapter>>,
-) -> IoResult<()> {
-    let char = characters
-        .get(conn.character)
-        .expect("Unwrapped None character");
-    let room = rooms.get(&char.in_room).expect("Unwrapped None room");
+pub fn look(conn_idx: Index, arguments: &str, world: &mut World) -> IoResult<()> {
+    let conn = world
+        .connections
+        .get_mut(conn_idx)
+        .expect("Unwrapped None connection");
     let (arg, _) = take_argument(arguments);
-    let chars_in_room = room_chars
-        .get(&char.in_room)
-        .expect("Unwrapped None room chars");
-    let objs_in_room = room_objs
-        .get(&char.in_room)
-        .expect("Unwrapped None room objs");
+
+    let room;
+    let chars_in_room;
+    let objs_in_room;
+    {
+        let char = world
+            .characters
+            .get(conn.character)
+            .expect("Unwrapped None character");
+        room = world.rooms.get(&char.in_room).expect("Unwrapped None room");
+        chars_in_room = world
+            .room_chars
+            .get(&char.in_room)
+            .expect("Unwrapped None room chars");
+        objs_in_room = world
+            .room_objs
+            .get(&char.in_room)
+            .expect("Unwrapped None room objs");
+    };
 
     match arg {
         Some("auto") | None => {
@@ -76,34 +69,45 @@ pub fn look(
             )?;
 
             for obj in objs_in_room {
-                write!(conn, "    {}\r\n", obj.room_description());
+                write!(conn, "    {}\r\n", obj.room_description())?;
             }
 
             let self_idx = conn.character;
-            for ch in chars_in_room.iter().filter_map(|&idx| {
-                if idx != self_idx {
-                    characters.get(idx)
-                } else {
-                    None
+            for char_idx in chars_in_room {
+                if *char_idx == self_idx {
+                    continue;
                 }
-            }) {
-                write!(conn, "{}\r\n", ch.room_description())?;
+                if let Some(ch) = world.characters.get(*char_idx) {
+                    write!(conn, "{}\r\n", ch.room_description())?;
+                }
             }
+            // for ch in chars_in_room.iter().copied().filter_map(|idx| {
+            //     if idx != self_idx {
+            //         world.characters.get(idx)
+            //     } else {
+            //         None
+            //     }
+            // }) {
+            //     write!(conn, "{}\r\n", ch.room_description())?;
+            // }
         }
         Some(a) => {
-            if let Some(target) = chars_in_room
-                .iter()
-                .filter_map(|idx| characters.get(*idx))
-                .find(|ch| ch.keywords().iter().any(|kw| kw.starts_with(a)))
-            {
-                // TODO: if self, "you look at yourself"...
-                write!(
-                    conn,
-                    "You look at {}.\r\n{}\r\n",
-                    target.formal_name(),
-                    target.description()
-                )?;
-            } else if let Some(target) = objs_in_room
+            for char_idx in chars_in_room {
+                if let Some(target) = world
+                    .characters
+                    .get(*char_idx)
+                    .filter(|ch| ch.keywords().iter().any(|kw| kw.starts_with(a)))
+                {
+                    write!(
+                        conn,
+                        "You look at {}.\r\n{}\r\n",
+                        target.formal_name(),
+                        target.description()
+                    )?;
+                    return Ok(());
+                }
+            }
+            if let Some(target) = objs_in_room
                 .iter()
                 .find(|obj| obj.keywords().iter().any(|kw| kw.starts_with(a)))
             {
@@ -116,74 +120,47 @@ pub fn look(
     Ok(())
 }
 
-fn north(
-    conn: &mut Connection,
-    _arguments: &str,
-    characters: &mut Arena<Character>,
-    rooms: &HashMap<RoomId, Room>,
-    room_chars: &mut HashMap<RoomId, Vec<Index>>,
-    room_objs: &mut HashMap<RoomId, LinkedList<ObjectInRoomAdapter>>,
-) -> IoResult<()> {
-    move_char(conn, "north", characters, rooms, room_chars, room_objs)
+fn north(conn_idx: Index, _arguments: &str, world: &mut World) -> IoResult<()> {
+    move_char(conn_idx, "north", world)
 }
 
-fn south(
-    conn: &mut Connection,
-    _arguments: &str,
-    characters: &mut Arena<Character>,
-    rooms: &HashMap<RoomId, Room>,
-    room_chars: &mut HashMap<RoomId, Vec<Index>>,
-    room_objs: &mut HashMap<RoomId, LinkedList<ObjectInRoomAdapter>>,
-) -> IoResult<()> {
-    move_char(conn, "south", characters, rooms, room_chars, room_objs)
+fn south(conn_idx: Index, _arguments: &str, world: &mut World) -> IoResult<()> {
+    move_char(conn_idx, "south", world)
 }
 
-fn east(
-    conn: &mut Connection,
-    _arguments: &str,
-    characters: &mut Arena<Character>,
-    rooms: &HashMap<RoomId, Room>,
-    room_chars: &mut HashMap<RoomId, Vec<Index>>,
-    room_objs: &mut HashMap<RoomId, LinkedList<ObjectInRoomAdapter>>,
-) -> IoResult<()> {
-    move_char(conn, "east", characters, rooms, room_chars, room_objs)
+fn east(conn_idx: Index, _arguments: &str, world: &mut World) -> IoResult<()> {
+    move_char(conn_idx, "east", world)
 }
 
-fn west(
-    conn: &mut Connection,
-    _arguments: &str,
-    characters: &mut Arena<Character>,
-    rooms: &HashMap<RoomId, Room>,
-    room_chars: &mut HashMap<RoomId, Vec<Index>>,
-    room_objs: &mut HashMap<RoomId, LinkedList<ObjectInRoomAdapter>>,
-) -> IoResult<()> {
-    move_char(conn, "west", characters, rooms, room_chars, room_objs)
+fn west(conn_idx: Index, _arguments: &str, world: &mut World) -> IoResult<()> {
+    move_char(conn_idx, "west", world)
 }
 
 // TODO: rename this to navigate_char, because it's using directions. move_char should be reserved
 // for moving a character directly to any arbitrary room.
-fn move_char(
-    conn: &mut Connection,
-    arguments: &str,
-    characters: &mut Arena<Character>,
-    rooms: &HashMap<RoomId, Room>,
-    room_chars: &mut HashMap<RoomId, Vec<Index>>,
-    room_objs: &mut HashMap<RoomId, LinkedList<ObjectInRoomAdapter>>,
-) -> IoResult<()> {
-    let char = characters
-        .get_mut(conn.character)
+fn move_char(conn_idx: Index, arguments: &str, world: &mut World) -> IoResult<()> {
+    let conn = world
+        .connections
+        .get(conn_idx)
+        .expect("Unwrapped None connection");
+    let char = world
+        .characters
+        .get(conn.character)
         .expect("Unwrapped None character");
-    if let Some(exit) = rooms
+    if let Some(exit) = world
+        .rooms
         .get(&char.in_room)
         .and_then(|room| room.exits.get(arguments))
     {
-        let to_room = rooms.get(&exit.to).expect("Unwrapped None room");
+        let to_room = world.rooms.get(&exit.to).expect("Unwrapped None room").id;
+        let char_idx = conn.character;
 
-        transfer_char(conn.character, to_room.id, characters, room_chars);
+        world.transport_char(char_idx, to_room);
         // TODO: make a more fundamental "do_look" function that doesn't need to look up the room
         // first (since we already have it)
-        look(conn, "auto", characters, rooms, room_chars, room_objs)?;
+        look(conn_idx, "auto", world)?;
     } else {
+        let conn = world.connections.get_mut(conn_idx).unwrap();
         write!(conn, "You can't go {}.\r\n", arguments)?;
     }
     Ok(())
@@ -212,38 +189,6 @@ pub fn lookup_command<'a, T>(commands: &'a [(&'static str, T)], command: &str) -
     found
 }
 
-// TODO: This is not a command; move it to a different module eventually
-pub fn transfer_char(
-    index: Index,
-    to_room: RoomId,
-    characters: &mut Arena<Character>,
-    room_chars: &mut HashMap<RoomId, Vec<Index>>,
-) -> Result<(), ()> {
-    let char = characters.get_mut(index).expect("Unwrapped None character");
-    let in_room = room_chars
-        .get_mut(&char.in_room)
-        .expect("Unwrapped None room chars");
-    if let Some(i) = in_room
-        .iter()
-        .enumerate()
-        .find(|(_, idx)| **idx == index)
-        .map(|(i, _)| i)
-    {
-        in_room.remove(i);
-    } else {
-        log::warn!("transfer_char: couldn't remove char from {}", char.in_room);
-    }
-    char.in_room = to_room;
-    // Add char index to new room
-    if let Some(in_room) = room_chars.get_mut(&char.in_room) {
-        in_room.push(index);
-        Ok(())
-    } else {
-        log::warn!("transfer_char: couldn't move to {}", to_room);
-        Err(())
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::lookup_command;
@@ -260,7 +205,7 @@ mod test {
     }
     use FakeCommand::*;
 
-    const commands: &[(&'static str, FakeCommand)] = &[
+    const COMMANDS: &[(&'static str, FakeCommand)] = &[
         ("north", North),
         ("northern", Northern),
         ("throwaway", ThrowAway),
@@ -272,21 +217,21 @@ mod test {
 
     #[test]
     fn find_exact_command() {
-        assert_eq!(Some(&North), lookup_command(&commands, "north"));
+        assert_eq!(Some(&North), lookup_command(&COMMANDS, "north"));
     }
 
     #[test]
     fn prioritize_earlier_matches() {
-        assert_eq!(Some(&North), lookup_command(&commands, "no"));
+        assert_eq!(Some(&North), lookup_command(&COMMANDS, "no"));
     }
 
     #[test]
     fn prioritize_exact_matches() {
-        assert_eq!(Some(&Throw), lookup_command(&commands, "throw"));
+        assert_eq!(Some(&Throw), lookup_command(&COMMANDS, "throw"));
     }
 
     #[test]
     fn find_partial_match() {
-        assert_eq!(Some(&There), lookup_command(&commands, "the"));
+        assert_eq!(Some(&There), lookup_command(&COMMANDS, "the"));
     }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -51,9 +51,11 @@ impl Connection {
         self.player.name()
     }
 
-    pub fn write_flush(&mut self, prompt: &str) -> IoResult<()> {
+    pub fn write_flush(&mut self, prompt: Option<&str>) -> IoResult<()> {
         if !self.output.is_empty() {
-            write!(self.output, "\r\n{}", prompt)?;
+            if let Some(prompt) = prompt {
+                write!(self.output, "\r\n{}", prompt)?;
+            }
             self.output.extend_from_slice(&[0xFF, 0xF9]);
             self.stream.write_all(&self.output)?;
             self.output.clear(); // TODO: find a way to shrink capacity down to 500 if poss?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,16 +8,18 @@ mod player;
 mod pronoun;
 mod room;
 pub mod util;
+pub mod world;
 
 pub use area::Area;
 pub use character::{CharId, Character};
-pub use commands::{define_commands, lookup_command};
+pub use commands::{lookup_command, COMMANDS};
 pub use connection::{Connection, ConnectionBuilder};
 pub use listener::listen;
 pub use object::{
-    AllobjectsAdapter, Object, ObjectDef, ObjectId, ObjectInRoomAdapter, ObjectOnCharAdapter,
+    AllObjectsAdapter, Object, ObjectDef, ObjectId, ObjectInRoomAdapter, ObjectOnCharAdapter,
     ObjectType,
 };
 pub use player::{Player, PlayerRecord};
 pub use pronoun::Pronoun;
 pub use room::{Exit, Room, RoomId};
+pub use world::World;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,123 +1,30 @@
 use crossbeam_channel::{bounded, Receiver};
 use femme::{self, LevelFilter};
-use fnv::FnvHashMap as HashMap;
-use generational_arena::{Arena, Index};
-use intrusive_collections::{LinkedList, LinkedListLink};
 use log;
-use std::io::{ErrorKind, Write};
+use std::io::Write;
 use std::net::TcpListener;
 use std::thread;
 use std::time::{Duration, Instant};
 
 use fennel::commands::look;
-use fennel::util::take_command;
-use fennel::{
-    define_commands, listen, lookup_command, AllobjectsAdapter, Area, CharId, Character,
-    Connection, ConnectionBuilder, Object, ObjectDef, ObjectId, ObjectInRoomAdapter, PlayerRecord,
-    Room, RoomId,
-};
-use std::rc::Rc;
+use fennel::{listen, ConnectionBuilder, PlayerRecord, RoomId, World};
 
 static PULSE_PER_SECOND: u32 = 3;
 static PULSE_RATE_NS: u32 = 1_000_000_000 / PULSE_PER_SECOND;
 
-fn audit_room_exits(rooms: &mut HashMap<RoomId, Room>) {
-    // I should be able to do this in a single iteration of room.values_mut(),
-    // and I'm angry that I can't.
-    let mut destinations_to_remove = vec![];
-    for room in rooms.values() {
-        for exit in room.exits.as_ref() {
-            if !rooms.contains_key(&exit.to) {
-                destinations_to_remove.push(exit.to)
-            }
-        }
-    }
-    if !destinations_to_remove.is_empty() {
-        for room in rooms.values_mut() {
-            for (n, exit) in room.exits.clone().as_ref().iter().enumerate() {
-                if destinations_to_remove.contains(&exit.to) {
-                    log::warn!(
-                        "Loading areas: removed room {}'s exit '{}' to nonexistant {}",
-                        room.id,
-                        &exit.dir,
-                        &exit.to
-                    );
-                    room.exits.remove(n);
-                }
-            }
-        }
-    }
-}
-
-fn load_areas() -> (
-    Vec<Area>,
-    HashMap<CharId, Character>,
-    HashMap<ObjectId, ObjectDef>,
-    HashMap<RoomId, Room>,
-) {
-    log::info!("Loading areas");
-    let mut areas = Vec::new();
-    let mut rooms = HashMap::default();
-    let mut object_defs = HashMap::default();
-    let mut npcs = HashMap::default();
-    // FIXME: daaaaaaang this is ugly
-    // TODO: we're gonna iterate over every area name in some text file, rather than load a single area
-    match Area::load("default") {
-        Ok(mut area_def) => {
-            let area_npcs = area_def.extract_npcs();
-            let area_objects = area_def.extract_objects();
-            let room_defs = area_def.extract_rooms();
-
-            let area = Area::from_prototype(area_def);
-            let area_idx = areas.len();
-            areas.push(area);
-            let area = &mut areas[area_idx];
-
-            for ch in area_npcs {
-                if npcs.contains_key(&ch.id()) {
-                    log::warn!("Loading areas: clobbered existing NPC {}", ch.id());
-                }
-                npcs.insert(ch.id(), ch);
-            }
-
-            for obj_def in area_objects {
-                object_defs.insert(obj_def.id, obj_def);
-            }
-
-            for room_def in room_defs {
-                let room = Room::from_prototype(room_def, area_idx);
-                if rooms.contains_key(&room.id) {
-                    log::warn!("Loading areas: clobbered existing room {}", room.id);
-                }
-                let room_idx = room.id;
-                rooms.insert(room.id, room);
-                area.rooms.push(room_idx);
-            }
-
-            audit_room_exits(&mut rooms);
-        }
-        Err(e) => log::error!("Error loading area {:?}", e),
-    }
-    log::info!("Loading areas: success");
-    (areas, npcs, object_defs, rooms)
-}
-
 fn accept_new_connections(
-    connections: &mut Arena<Connection>,
-    characters: &mut Arena<Character>,
-    rooms: &HashMap<RoomId, Room>,
-    room_chars: &mut HashMap<RoomId, Vec<Index>>,
-    room_objs: &mut HashMap<RoomId, LinkedList<ObjectInRoomAdapter>>,
+    world: &mut World,
     receiver: &Receiver<(ConnectionBuilder, PlayerRecord)>,
 ) {
     while let Ok((conn_builder, record)) = receiver.try_recv() {
         let (player, char) = record.into_inner();
 
-        let mut conn = if let Some((conn_index, _existing_conn)) = connections
+        let conn = if let Some((conn_index, _existing_conn)) = world
+            .connections
             .iter()
             .find(|(_, c)| c.player_name() == player.name())
         {
-            let existing_conn = connections.remove(conn_index).unwrap();
+            let existing_conn = world.connections.remove(conn_index).unwrap();
             log::info!(
                 "Connection overridden from {} to {} for {}",
                 existing_conn.addr(),
@@ -125,7 +32,8 @@ fn accept_new_connections(
                 player.name()
             );
             conn_builder.logged_in(player, existing_conn.character)
-        } else if let Some((char_idx, _char)) = characters
+        } else if let Some((char_idx, _char)) = world
+            .characters
             .iter()
             .find(|(_, c)| c.keywords()[0] == player.name() && c.id() == Default::default())
         {
@@ -146,23 +54,25 @@ fn accept_new_connections(
 
             // Ensure that the character's room still exists.
             let mut char = char;
-            if rooms.get(&char.in_room).is_none() {
+            if world.rooms.get(&char.in_room).is_none() {
                 char.in_room = RoomId::default();
             }
 
-            let in_room = room_chars
+            let in_room = world
+                .room_chars
                 .get_mut(&char.in_room)
                 .expect("Unwrapped None room chars");
-            let char_idx = characters.insert(char);
-            characters
+            let char_idx = world.characters.insert(char);
+            world
+                .characters
                 .get_mut(char_idx)
                 .map(|char| char.set_index(char_idx));
             in_room.push(char_idx);
             conn_builder.logged_in(player, char_idx)
         };
 
-        let _ = look(&mut conn, "auto", characters, rooms, room_chars, room_objs);
-        let _conn_idx = connections.insert(conn);
+        let conn_idx = world.connections.insert(conn);
+        let _ = look(conn_idx, "auto", world);
     }
 }
 
@@ -170,112 +80,24 @@ fn game_loop(
     connection_receiver: Receiver<(ConnectionBuilder, PlayerRecord)>,
 ) -> std::io::Result<()> {
     let mut last_time: Instant;
-    let mut connections: Arena<Connection> = Arena::new();
-    let mut characters: Arena<Character> = Arena::new();
-    let mut objects = LinkedList::new(AllobjectsAdapter::new());
-    let mut mark_for_disconnect = Vec::new();
 
-    let commands = define_commands();
-    let (areas, npcs, object_defs, rooms) = load_areas();
-    let mut room_chars: HashMap<RoomId, Vec<Index>> = HashMap::default();
-    let mut room_objs: HashMap<RoomId, LinkedList<ObjectInRoomAdapter>> = HashMap::default();
-    for key in rooms.keys() {
-        room_chars.insert(*key, vec![]);
-        room_objs.insert(*key, Default::default());
-    }
+    let mut world = World::new();
 
-    for npc in npcs.values() {
-        let idx = characters.insert(npc.clone());
-        characters.get_mut(idx).map(|char| char.set_index(idx));
-        let in_room = room_chars
-            .get_mut(&npc.in_room)
-            .expect("Unwrapped None room chars");
-        in_room.push(idx);
-    }
-
-    // FIXME: hackity hack-hack
-    for room in rooms.values() {
-        for id in &room.object_ids {
-            let obj = Rc::new(Object::from_prototype(&object_defs[id]));
-            objects.push_front(obj.clone());
-            room_objs.get_mut(&room.id).unwrap().push_front(obj);
-        }
-    }
-
-    println!("{:?}\n\n{:?}\n\n{:?}\n\n{:?}", areas, npcs, objects, rooms);
+    world.populate();
 
     loop {
         last_time = Instant::now();
 
-        accept_new_connections(
-            &mut connections,
-            &mut characters,
-            &rooms,
-            &mut room_chars,
-            &mut room_objs,
-            &connection_receiver,
-        );
+        accept_new_connections(&mut world, &connection_receiver);
 
-        // handle input
-        for (idx, conn) in &mut connections {
-            match conn.read() {
-                Ok(input) if !input.is_empty() => conn.input = Some(input),
-                Ok(_) => {
-                    log::debug!("Marking linkdead {}: zero length input", conn.addr());
-                    mark_for_disconnect.push(idx);
-                }
-                Err(e) => {
-                    match e.kind() {
-                        ErrorKind::ConnectionAborted | ErrorKind::ConnectionReset => {
-                            log::debug!("Marking linkdead {}: {}", conn.addr(), e);
-                            mark_for_disconnect.push(idx);
-                        }
-                        ErrorKind::WouldBlock => {} // explicitly okay no matter what happens to the catch-all branch
-                        _ => log::warn!(
-                            "Unexpected input read error from {}: {:?} {}",
-                            conn.addr(),
-                            e.kind(),
-                            e
-                        ),
-                    }
-                }
-            }
-            // decrement lag
+        // TODO: decrement lag here
 
-            // interpret input
-        }
+        world.read_input();
 
-        for idx in &mark_for_disconnect {
-            if let Some(_conn) = connections.remove(*idx) {
-                // TODO: close connection
-            }
-        }
-        mark_for_disconnect.clear();
-
-        // update world
-        for (_idx, conn) in &mut connections {
-            if let Some(input) = conn.input.take() {
-                if let Some((command, rest)) = take_command(&input) {
-                    let _ = if let Some(cmd) = lookup_command(&commands, command) {
-                        cmd(
-                            conn,
-                            rest,
-                            &mut characters,
-                            &rooms,
-                            &mut room_chars,
-                            &mut room_objs,
-                        )
-                    } else {
-                        write!(conn, "I have no idea what that means!")
-                    };
-                } else {
-                    write!(conn, "\r\n");
-                }
-            }
-        }
+        world.run_player_commands();
 
         // handle output
-        for (_idx, conn) in &mut connections {
+        for (_idx, conn) in &mut world.connections {
             let _ =
                 conn.write_flush("You are who you are; You are where you are; The time is now>");
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,7 @@ fn accept_new_connections(
                 char.in_room = RoomId::default();
             }
 
+            // TODO: use world.char_to_room here for consistency
             let in_room = world
                 .room_chars
                 .get_mut(&char.in_room)
@@ -98,8 +99,9 @@ fn game_loop(
 
         // handle output
         for (_idx, conn) in &mut world.connections {
-            let _ =
-                conn.write_flush("You are who you are; You are where you are; The time is now>");
+            let _ = conn.write_flush(Some(
+                "You are who you are; You are where you are; The time is now>",
+            ));
         }
 
         let now = Instant::now();

--- a/src/object.rs
+++ b/src/object.rs
@@ -19,7 +19,7 @@ pub struct ObjectDef {
 
 intrusive_adapter!(pub ObjectInRoomAdapter = Rc<Object>: Object { in_room_link: LinkedListLink });
 intrusive_adapter!(pub ObjectOnCharAdapter = Rc<Object>: Object { on_char_link: LinkedListLink });
-intrusive_adapter!(pub AllobjectsAdapter = Rc<Object>: Object { all_objs_link: LinkedListLink });
+intrusive_adapter!(pub AllObjectsAdapter = Rc<Object>: Object { all_objs_link: LinkedListLink });
 
 #[derive(Clone, Debug, Default)]
 pub struct Object {

--- a/src/util/save.rs
+++ b/src/util/save.rs
@@ -7,5 +7,11 @@ pub fn save(name: &str, player_record: PlayerRecord) -> Result<()> {
     let mut f = File::create(PlayerRecord::file_path(name))?;
     serde_json::to_writer_pretty(&mut f, &player_record)
         .map_err(|e| Error::new(ErrorKind::Other, e))?;
-    f.sync_data()
+    match f.sync_data() {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            log::error!("SAVE ERROR for {}: {}", name, e);
+            Err(e)
+        }
+    }
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,0 +1,253 @@
+use crate::area::Area;
+use crate::character::{CharId, Character};
+use crate::commands::{lookup_command, CommandFn, COMMANDS};
+use crate::connection::Connection;
+use crate::object::{AllObjectsAdapter, Object, ObjectDef, ObjectId, ObjectInRoomAdapter};
+use crate::room::{Room, RoomId};
+use crate::util::take_command;
+use fnv::FnvHashMap;
+use generational_arena::{Arena, Index};
+use intrusive_collections::LinkedList;
+use std::default::Default;
+use std::io::{ErrorKind, Write};
+use std::rc::Rc;
+
+pub struct PendingCommand {
+    conn_idx: Index,
+    at_room: RoomId,
+    command: Option<&'static CommandFn>,
+    arguments: String,
+}
+
+#[derive(Default)]
+pub struct World {
+    pub connections: Arena<Connection>,
+    mark_for_disconnect: Vec<Index>,
+    pub areas: Vec<Area>,
+    pub npc_defs: FnvHashMap<CharId, Character>,
+    pub characters: Arena<Character>,
+    pub object_defs: FnvHashMap<ObjectId, ObjectDef>,
+    pub objects: LinkedList<AllObjectsAdapter>,
+    pub rooms: FnvHashMap<RoomId, Room>,
+    pub room_chars: FnvHashMap<RoomId, Vec<Index>>, // Linked list?
+    pub room_objs: FnvHashMap<RoomId, LinkedList<ObjectInRoomAdapter>>,
+    pending_commands: std::collections::LinkedList<PendingCommand>,
+}
+
+impl World {
+    pub fn new() -> World {
+        let (areas, npc_defs, object_defs, rooms) = load_areas();
+
+        let mut room_chars: FnvHashMap<RoomId, Vec<Index>> = FnvHashMap::default();
+        let mut room_objs: FnvHashMap<RoomId, LinkedList<ObjectInRoomAdapter>> =
+            FnvHashMap::default();
+        for key in rooms.keys() {
+            room_chars.insert(*key, vec![]);
+            room_objs.insert(*key, Default::default());
+        }
+
+        // println!("{:?}\n\n{:?}\n\n{:?}\n\n{:?}", areas, npc_defs, object_defs, rooms);
+
+        World {
+            areas,
+            npc_defs,
+            object_defs,
+            rooms,
+            room_chars,
+            room_objs,
+            ..Default::default()
+        }
+    }
+
+    pub fn populate(&mut self) {
+        for npc in self.npc_defs.values() {
+            let idx = self.characters.insert(npc.clone());
+            self.characters.get_mut(idx).map(|char| char.set_index(idx));
+            let in_room = self
+                .room_chars
+                .get_mut(&npc.in_room)
+                .expect("Unwrapped None room chars");
+            in_room.push(idx);
+        }
+
+        // FIXME: hackity hack-hack
+        for room in self.rooms.values() {
+            for id in &room.object_ids {
+                let obj = Rc::new(Object::from_prototype(&self.object_defs[id]));
+                self.objects.push_front(obj.clone());
+                let in_room = self
+                    .room_objs
+                    .get_mut(&room.id)
+                    .expect("Unwrapped None room objs");
+                in_room.push_front(obj);
+            }
+        }
+    }
+
+    pub fn read_input(&mut self) {
+        for (idx, conn) in &mut self.connections {
+            match conn.read() {
+                Ok(input) if !input.is_empty() => {
+                    if let Some((command, rest)) = take_command(&input) {
+                        let pending = PendingCommand {
+                            conn_idx: idx,
+                            at_room: self.characters[conn.character].in_room,
+                            command: lookup_command(COMMANDS, command),
+                            arguments: rest.to_string(),
+                        };
+                        self.pending_commands.push_back(pending);
+                    }
+                }
+                Ok(_) => {
+                    log::debug!("Marking linkdead {}: zero length input", conn.addr());
+                    self.mark_for_disconnect.push(idx);
+                }
+                Err(e) => {
+                    match e.kind() {
+                        ErrorKind::ConnectionAborted | ErrorKind::ConnectionReset => {
+                            log::debug!("Marking linkdead {}: {}", conn.addr(), e);
+                            self.mark_for_disconnect.push(idx);
+                        }
+                        ErrorKind::WouldBlock => {} // explicitly okay no matter what happens to the catch-all branch
+                        _ => log::warn!(
+                            "Unexpected input read error from {}: {:?} {}",
+                            conn.addr(),
+                            e.kind(),
+                            e
+                        ),
+                    }
+                }
+            }
+        }
+        for idx in &self.mark_for_disconnect {
+            if let Some(_conn) = self.connections.remove(*idx) {
+                // TODO: close connection
+            }
+        }
+        self.mark_for_disconnect.clear();
+    }
+
+    pub fn run_player_commands(&mut self) {
+        let pending_commands = self.pending_commands.split_off(0);
+        for pending in pending_commands {
+            match pending.command {
+                Some(command) => {
+                    let _ = (command)(pending.conn_idx, &pending.arguments, self);
+                }
+                None => {
+                    let conn = &mut self.connections[pending.conn_idx];
+                    let _ = write!(conn, "I have no idea what that means!");
+                }
+            }
+        }
+    }
+
+    pub fn transport_char(&mut self, char_idx: Index, to_room: RoomId) {
+        let char = self
+            .characters
+            .get_mut(char_idx)
+            .expect("Unwrapped None character");
+        let in_room = self
+            .room_chars
+            .get_mut(&char.in_room)
+            .expect("Unwrapped None room chars");
+        if let Some(i) = in_room
+            .iter()
+            .enumerate()
+            .find(|(_, idx)| **idx == char_idx)
+            .map(|(i, _)| i)
+        {
+            in_room.remove(i);
+        } else {
+            log::warn!("transfer_char: couldn't remove char from {}", char.in_room);
+        }
+        char.in_room = to_room;
+        // Add char index to new room
+        if let Some(in_room) = self.room_chars.get_mut(&char.in_room) {
+            in_room.push(char_idx);
+        } else {
+            log::warn!("transfer_char: couldn't move to {}", to_room);
+        }
+    }
+}
+
+fn load_areas() -> (
+    Vec<Area>,
+    FnvHashMap<CharId, Character>,
+    FnvHashMap<ObjectId, ObjectDef>,
+    FnvHashMap<RoomId, Room>,
+) {
+    log::info!("Loading areas");
+    let mut areas = Vec::new();
+    let mut rooms = FnvHashMap::default();
+    let mut object_defs = FnvHashMap::default();
+    let mut npcs = FnvHashMap::default();
+    // FIXME: daaaaaaang this is ugly
+    // TODO: we're gonna iterate over every area name in some text file, rather than load a single area
+    match Area::load("default") {
+        Ok(mut area_def) => {
+            let area_npcs = area_def.extract_npcs();
+            let area_objects = area_def.extract_objects();
+            let room_defs = area_def.extract_rooms();
+
+            let area = Area::from_prototype(area_def);
+            let area_idx = areas.len();
+            areas.push(area);
+            let area = &mut areas[area_idx];
+
+            for ch in area_npcs {
+                if npcs.contains_key(&ch.id()) {
+                    log::warn!("Loading areas: clobbered existing NPC {}", ch.id());
+                }
+                npcs.insert(ch.id(), ch);
+            }
+
+            for obj_def in area_objects {
+                object_defs.insert(obj_def.id, obj_def);
+            }
+
+            for room_def in room_defs {
+                let room = Room::from_prototype(room_def, area_idx);
+                if rooms.contains_key(&room.id) {
+                    log::warn!("Loading areas: clobbered existing room {}", room.id);
+                }
+                let room_idx = room.id;
+                rooms.insert(room.id, room);
+                area.rooms.push(room_idx);
+            }
+
+            audit_room_exits(&mut rooms);
+        }
+        Err(e) => log::error!("Error loading area {:?}", e),
+    }
+    log::info!("Loading areas: success");
+    (areas, npcs, object_defs, rooms)
+}
+
+fn audit_room_exits(rooms: &mut FnvHashMap<RoomId, Room>) {
+    // I should be able to do this in a single iteration of room.values_mut(),
+    // and I'm angry that I can't.
+    let mut destinations_to_remove = vec![];
+    for room in rooms.values() {
+        for exit in room.exits.as_ref() {
+            if !rooms.contains_key(&exit.to) {
+                destinations_to_remove.push(exit.to)
+            }
+        }
+    }
+    if !destinations_to_remove.is_empty() {
+        for room in rooms.values_mut() {
+            for (n, exit) in room.exits.clone().as_ref().iter().enumerate() {
+                if destinations_to_remove.contains(&exit.to) {
+                    log::warn!(
+                        "Loading areas: removed room {}'s exit '{}' to nonexistant {}",
+                        room.id,
+                        &exit.dir,
+                        &exit.to
+                    );
+                    room.exits.remove(n);
+                }
+            }
+        }
+    }
+}

--- a/src/world.rs
+++ b/src/world.rs
@@ -142,14 +142,10 @@ impl World {
         }
     }
 
-    pub fn transport_char(&mut self, char_idx: Index, to_room: RoomId) {
-        let char = self
-            .characters
-            .get_mut(char_idx)
-            .expect("Unwrapped None character");
+    pub fn char_from_room(&mut self, char_idx: Index, from_room: RoomId) {
         let in_room = self
             .room_chars
-            .get_mut(&char.in_room)
+            .get_mut(&from_room)
             .expect("Unwrapped None room chars");
         if let Some(i) = in_room
             .iter()
@@ -159,8 +155,15 @@ impl World {
         {
             in_room.remove(i);
         } else {
-            log::warn!("transfer_char: couldn't remove char from {}", char.in_room);
+            log::warn!("transfer_char: couldn't remove char from {}", from_room);
         }
+    }
+
+    pub fn char_to_room(&mut self, char_idx: Index, to_room: RoomId) {
+        let char = self
+            .characters
+            .get_mut(char_idx)
+            .expect("Unwrapped None character");
         char.in_room = to_room;
         // Add char index to new room
         if let Some(in_room) = self.room_chars.get_mut(&char.in_room) {


### PR DESCRIPTION
Collapse the unwieldy, ever-growing sequence of collections (`&mut Arena<Character>, &HashMap<RoomId, Room>, &mut HashMap<RoomId, Vec<Index>>, &mut HashMap<RoomId, LinkedList<ObjectInRoomAdapter>>`) that I must pass into player command functions down to `&mut World`.

Untangling the ownership issues that prevented this for so long also ended up enabling me to mutably borrow connections inside command functions, so now we can do cool things like, uh, quit the game.